### PR TITLE
fix: refactor leave request in admin view

### DIFF
--- a/apps/leave-requests/app/admin/leave-requests/page.tsx
+++ b/apps/leave-requests/app/admin/leave-requests/page.tsx
@@ -2,7 +2,7 @@ import { PageContainer } from "@workspace/ui/components/page-container";
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
 import { Badge } from "@workspace/ui/components/badge";
 import { createServerClient } from "@workspace/supabase";
-import { LeaveRequestList } from "@/components/leave/leave-request-list";
+import { AllLeaveRequestsTable } from "@/components/admin/all-leave-requests-table";
 import { Button } from "@workspace/ui/components/button";
 import { FileText, Filter, Download } from "lucide-react";
 import Link from "next/link";
@@ -22,11 +22,7 @@ export default async function AdminLeaveRequestsPage() {
     `)
     .order("created_at", { ascending: false });
 
-  // Separate requests by status
-  const pendingRequests = allLeaveRequests?.filter(req => req.status === "pending") || [];
-  const approvedRequests = allLeaveRequests?.filter(req => req.status === "approved") || [];
-  const rejectedRequests = allLeaveRequests?.filter(req => req.status === "rejected") || [];
-  const canceledRequests = allLeaveRequests?.filter(req => req.status === "canceled") || [];
+
 
   const getStatusCount = (status: string) => {
     return allLeaveRequests?.filter(req => req.status === status).length || 0;
@@ -76,55 +72,12 @@ export default async function AdminLeaveRequestsPage() {
           </Card>
         </div>
 
-        {/* Pending Requests */}
-        {pendingRequests.length > 0 && (
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Pending Requests</h2>
-            <LeaveRequestList
-              leaveRequests={pendingRequests}
-              title="Requests Awaiting Approval"
-              showUserColumn={true}
-              showActions={true}
-            />
-          </div>
-        )}
-
-        {/* Approved Requests */}
-        {approvedRequests.length > 0 && (
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Approved Requests</h2>
-            <LeaveRequestList
-              leaveRequests={approvedRequests}
-              title="Recently Approved"
-              showUserColumn={true}
-              showActions={false}
-            />
-          </div>
-        )}
-
-        {/* Rejected Requests */}
-        {rejectedRequests.length > 0 && (
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Rejected Requests</h2>
-            <LeaveRequestList
-              leaveRequests={rejectedRequests}
-              title="Recently Rejected"
-              showUserColumn={true}
-              showActions={false}
-            />
-          </div>
-        )}
-
-        {/* All Requests */}
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold">All Leave Requests</h2>
-          <LeaveRequestList
-            leaveRequests={allLeaveRequests || []}
-            title="Complete History"
-            showUserColumn={true}
-            showActions={false}
-          />
-        </div>
+        {/* All Leave Requests */}
+        <AllLeaveRequestsTable
+          leaveRequests={allLeaveRequests || []}
+          title="All Leave Requests"
+          showActions={true}
+        />
       </div>
     </PageContainer>
   );

--- a/apps/leave-requests/app/admin/page.tsx
+++ b/apps/leave-requests/app/admin/page.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@workspace/ui/components/badge";
 import { Calendar, Trophy, Users, Gift, FileText } from "lucide-react";
 import { getThisMonthAnniversaries } from "@/lib/anniversary-utils";
 import { getThisMonthBirthdays } from "@/lib/birthday-utils";
-import { LeaveRequestList } from "@/components/leave/leave-request-list";
+import { PendingLeaveRequestsTable } from "@/components/admin/pending-leave-requests-table";
 import { createServerClient } from "@workspace/supabase";
 
 export default async function AdminPage() {
@@ -61,31 +61,7 @@ export default async function AdminPage() {
           <h1 className="text-3xl font-bold mb-4">Welcome, Admin!</h1>
           <p className="text-gray-600">This is the admin dashboard. Here you can manage users, view reports, and configure settings.</p>
         </div>
-        
-        {/* Pending Leave Requests */}
-        {pendingRequests.length > 0 && (
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Pending Leave Requests</h2>
-            <LeaveRequestList
-              leaveRequests={pendingRequests}
-              title="Requests Awaiting Approval"
-              showUserColumn={true}
-              showActions={true}
-            />
-          </div>
-        )}
 
-        {/* No Pending Requests Message */}
-        {pendingRequests.length === 0 && (
-          <Card>
-            <CardContent className="p-8 text-center">
-              <FileText className="h-16 w-16 mx-auto mb-4 text-gray-300" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No Pending Requests</h3>
-              <p className="text-gray-500">All leave requests have been processed.</p>
-            </CardContent>
-          </Card>
-        )}
-        
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <Card>
             <CardHeader>
@@ -175,6 +151,26 @@ export default async function AdminPage() {
             </CardContent>
           </Card>
         </div>
+        
+        {/* Pending Leave Requests */}
+        {pendingRequests.length > 0 && (
+          <PendingLeaveRequestsTable
+            leaveRequests={pendingRequests}
+          />
+        )}
+
+        {/* No Pending Requests Message */}
+        {pendingRequests.length === 0 && (
+          <Card>
+            <CardContent className="p-8 text-center">
+              <FileText className="h-16 w-16 mx-auto mb-4 text-gray-300" />
+              <h3 className="text-lg font-medium text-gray-900 mb-2">No Pending Requests</h3>
+              <p className="text-gray-500">All leave requests have been processed.</p>
+            </CardContent>
+          </Card>
+        )}
+        
+
       </div>
     </PageContainer>
   );

--- a/apps/leave-requests/components/admin/all-leave-requests-table.tsx
+++ b/apps/leave-requests/components/admin/all-leave-requests-table.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
+import { Badge } from "@workspace/ui/components/badge";
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from "@workspace/ui/components/table";
+import { Calendar, Clock, User, FileText, AlertCircle, CheckCircle, XCircle, MinusCircle } from "lucide-react";
+import { LeaveRequest } from "@/types";
+import { LeaveRequestActions } from "@/components/admin/leave-request-actions";
+import { getStatusBadge, formatDateRange, getDurationText } from "@/lib/leave-request-display-utils";
+
+interface AllLeaveRequestsTableProps {
+  leaveRequests: LeaveRequest[];
+  title: string;
+  showActions?: boolean;
+  onActionComplete?: () => void;
+}
+
+export function AllLeaveRequestsTable({
+  leaveRequests,
+  title,
+  showActions = false,
+  onActionComplete,
+}: AllLeaveRequestsTableProps) {
+  const [requests, setRequests] = useState(leaveRequests);
+
+  const handleActionComplete = () => {
+    if (onActionComplete) {
+      onActionComplete();
+    } else {
+      window.location.reload();
+    }
+  };
+
+  if (leaveRequests.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-8 text-gray-500">
+            <FileText className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+            <p>No leave requests found</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'pending':
+        return <AlertCircle className="h-4 w-4 text-yellow-500" />;
+      case 'approved':
+        return <CheckCircle className="h-4 w-4 text-green-500" />;
+      case 'rejected':
+        return <XCircle className="h-4 w-4 text-red-500" />;
+      case 'canceled':
+        return <MinusCircle className="h-4 w-4 text-gray-500" />;
+      default:
+        return <FileText className="h-4 w-4 text-gray-500" />;
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          {title}
+          <Badge variant="outline" className="ml-2">
+            {leaveRequests.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[120px]">Status</TableHead>
+                <TableHead className="w-[200px]">Employee</TableHead>
+                <TableHead className="w-[150px]">Leave Type</TableHead>
+                <TableHead className="w-[200px]">Date Range</TableHead>
+                <TableHead className="w-[100px]">Duration</TableHead>
+                <TableHead className="w-[200px]">Projects</TableHead>
+                <TableHead className="w-[200px]">Reason</TableHead>
+                <TableHead className="w-[150px]">Submitted</TableHead>
+                <TableHead className="w-[150px]">Processed</TableHead>
+                {showActions && <TableHead className="w-[120px]">Actions</TableHead>}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {leaveRequests.map((request) => (
+                <TableRow key={request.id} className="hover:bg-gray-50">
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      {getStatusIcon(request.status)}
+                      {getStatusBadge(request.status)}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <User className="h-4 w-4 text-gray-500" />
+                      <div>
+                        <div className="font-medium text-gray-900">
+                          {request.user?.full_name || 'Unknown User'}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          {request.user?.email || 'No email'}
+                        </div>
+                      </div>
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.leave_type ? (
+                      <Badge variant="outline" className="text-xs">
+                        {request.leave_type.name}
+                      </Badge>
+                    ) : (
+                      <span className="text-gray-400 text-sm">No type</span>
+                    )}
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Calendar className="h-4 w-4 text-gray-500" />
+                      {formatDateRange(request.start_date, request.end_date, request.is_half_day, request.half_day_type)}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Clock className="h-4 w-4 text-gray-500" />
+                      {getDurationText(request.start_date, request.end_date, request.is_half_day)}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.projects && request.projects.length > 0 ? (
+                      <div className="space-y-1">
+                        {request.projects.map((project) => (
+                          <Badge key={project.id} variant="secondary" className="text-xs">
+                            {project.name}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400 text-sm">No projects</span>
+                    )}
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.message ? (
+                      <div className="max-w-[180px]">
+                        <p className="text-sm text-gray-700 truncate" title={request.message}>
+                          {request.message}
+                        </p>
+                      </div>
+                    ) : (
+                      <span className="text-gray-400 text-sm">No reason</span>
+                    )}
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="text-sm text-gray-600">
+                      {new Date(request.created_at).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric'
+                      })}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.status === 'approved' && request.approved_at ? (
+                      <div className="text-sm text-green-600">
+                        <div className="font-medium">Approved</div>
+                        <div className="text-xs">
+                          {new Date(request.approved_at).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric'
+                          })}
+                        </div>
+                        {request.approved_by && (
+                          <div className="text-xs text-gray-500">
+                            by {request.approved_by.full_name}
+                          </div>
+                        )}
+                      </div>
+                    ) : request.status === 'rejected' ? (
+                      <div className="text-sm text-red-600">
+                        <div className="font-medium">Rejected</div>
+                        {request.approval_notes && (
+                          <div className="text-xs text-gray-500 truncate" title={request.approval_notes}>
+                            {request.approval_notes}
+                          </div>
+                        )}
+                      </div>
+                    ) : request.status === 'canceled' ? (
+                      <div className="text-sm text-gray-600">
+                        <div className="font-medium">Canceled</div>
+                        {request.cancel_reason && (
+                          <div className="text-xs text-gray-500 truncate" title={request.cancel_reason}>
+                            {request.cancel_reason}
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400 text-sm">-</span>
+                    )}
+                  </TableCell>
+                  
+                  {showActions && (
+                    <TableCell>
+                      {request.status === "pending" && (
+                        <div className="flex items-center gap-2">
+                          <LeaveRequestActions 
+                            request={request} 
+                            onActionComplete={handleActionComplete}
+                          />
+                        </div>
+                      )}
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+} 

--- a/apps/leave-requests/components/admin/pending-leave-requests-table.tsx
+++ b/apps/leave-requests/components/admin/pending-leave-requests-table.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
+import { Badge } from "@workspace/ui/components/badge";
+import { Button } from "@workspace/ui/components/button";
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from "@workspace/ui/components/table";
+import { Calendar, Clock, User, FileText, AlertCircle, Eye } from "lucide-react";
+import { LeaveRequest } from "@/types";
+import { LeaveRequestActions } from "@/components/admin/leave-request-actions";
+import { getStatusBadge, formatDateRange, getDurationText } from "@/lib/leave-request-display-utils";
+
+interface PendingLeaveRequestsTableProps {
+  leaveRequests: LeaveRequest[];
+  onActionComplete?: () => void;
+}
+
+export function PendingLeaveRequestsTable({
+  leaveRequests,
+  onActionComplete,
+}: PendingLeaveRequestsTableProps) {
+  const [requests, setRequests] = useState(leaveRequests);
+
+  const handleActionComplete = () => {
+    // Remove the request from local state after action
+    // In a real app, you'd want to refresh the data from the server
+    if (onActionComplete) {
+      onActionComplete();
+    } else {
+      window.location.reload();
+    }
+  };
+
+  if (leaveRequests.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Pending Leave Requests
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-8 text-gray-500">
+            <FileText className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+            <p>No pending leave requests found</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <AlertCircle className="h-5 w-5 text-yellow-500" />
+          Pending Leave Requests
+          <Badge variant="outline" className="ml-2">
+            {leaveRequests.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[200px]">Employee</TableHead>
+                <TableHead className="w-[150px]">Leave Type</TableHead>
+                <TableHead className="w-[200px]">Date Range</TableHead>
+                <TableHead className="w-[100px]">Duration</TableHead>
+                <TableHead className="w-[200px]">Projects</TableHead>
+                <TableHead className="w-[200px]">Reason</TableHead>
+                <TableHead className="w-[150px]">Submitted</TableHead>
+                <TableHead className="w-[120px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {leaveRequests.map((request) => (
+                <TableRow key={request.id} className="hover:bg-gray-50">
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <User className="h-4 w-4 text-gray-500" />
+                      <div>
+                        <div className="font-medium text-gray-900">
+                          {request.user?.full_name || 'Unknown User'}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          {request.user?.email || 'No email'}
+                        </div>
+                      </div>
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.leave_type ? (
+                      <Badge variant="outline" className="text-xs">
+                        {request.leave_type.name}
+                      </Badge>
+                    ) : (
+                      <span className="text-gray-400 text-sm">No type</span>
+                    )}
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Calendar className="h-4 w-4 text-gray-500" />
+                      {formatDateRange(request.start_date, request.end_date, request.is_half_day, request.half_day_type)}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Clock className="h-4 w-4 text-gray-500" />
+                      {getDurationText(request.start_date, request.end_date, request.is_half_day)}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.projects && request.projects.length > 0 ? (
+                      <div className="space-y-1">
+                        {request.projects.map((project) => (
+                          <Badge key={project.id} variant="secondary" className="text-xs">
+                            {project.name}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400 text-sm">No projects</span>
+                    )}
+                  </TableCell>
+                  
+                  <TableCell>
+                    {request.message ? (
+                      <div className="max-w-[180px]">
+                        <p className="text-sm text-gray-700 truncate" title={request.message}>
+                          {request.message}
+                        </p>
+                      </div>
+                    ) : (
+                      <span className="text-gray-400 text-sm">No reason</span>
+                    )}
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="text-sm text-gray-600">
+                      {new Date(request.created_at).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric'
+                      })}
+                    </div>
+                  </TableCell>
+                  
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <LeaveRequestActions 
+                        request={request} 
+                        onActionComplete={handleActionComplete}
+                      />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+} 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified “All Leave Requests” table for admins, showing status, employee, type, date range, duration, projects, reason, submitted/processed info, and optional actions. Includes clear empty-state messaging and request counts.
  * Added a dedicated “Pending Leave Requests” table with inline actions and an improved empty state.

* **Refactor**
  * Simplified admin leave request pages by replacing multiple status-specific lists with the new tables, delivering a cleaner, more consistent UI. Quick stats remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->