### PR TITLE
feat(db): Update user creation logic in users table trigger

### DIFF
--- a/apps/leave-requests/supabase/migrations/20250712072709_create_users_table.sql
+++ b/apps/leave-requests/supabase/migrations/20250712072709_create_users_table.sql
@@ -31,10 +31,12 @@ as $$
 begin
   -- If user already exists in public.users by email, update their id to match auth.users.id
   if exists (select 1 from public.users where email = new.email) then
+    -- update for public.users table
     update public.users
-    set id = new.id,
+    set 
+        id = new.id,
         full_name = coalesce(new.raw_user_meta_data->>'full_name', full_name),
-        email = new.email
+        updated_at = now()
     where email = new.email;
 
   -- Else insert a new user row

--- a/apps/leave-requests/supabase/migrations/20250908080645_update_foreign_keys_on_cascade.sql
+++ b/apps/leave-requests/supabase/migrations/20250908080645_update_foreign_keys_on_cascade.sql
@@ -1,0 +1,39 @@
+-- leave_requests
+alter table public.leave_requests
+drop constraint if exists leave_requests_user_id_fkey,
+add constraint leave_requests_user_id_fkey
+foreign key (user_id) references public.users(id)
+on update cascade
+on delete cascade;
+
+-- project_assignments
+alter table public.project_assignments
+drop constraint if exists project_assignments_user_id_fkey,
+add constraint project_assignments_user_id_fkey
+foreign key (user_id) references public.users(id)
+on update cascade
+on delete cascade;
+
+-- addresses
+alter table public.addresses
+drop constraint if exists addresses_user_id_fkey,
+add constraint addresses_user_id_fkey
+foreign key (user_id) references public.users(id)
+on update cascade
+on delete cascade;
+
+-- extended_absences
+alter table public.extended_absences
+drop constraint if exists extended_absences_user_id_fkey,
+add constraint extended_absences_user_id_fkey
+foreign key (user_id) references public.users(id)
+on update cascade
+on delete cascade;
+
+-- bonus_leave_grants
+alter table public.bonus_leave_grants
+drop constraint if exists bonus_leave_grants_user_id_fkey,
+add constraint bonus_leave_grants_user_id_fkey
+foreign key (user_id) references public.users(id)
+on update cascade
+on delete cascade;


### PR DESCRIPTION
## What
- Updates the `users` table trigger to either update an existing user or insert a new one based on email.
- If a user with the same email exists, update the `id` and `full_name` to match auth.users.
- If no user with the email exists, insert a new user record.
- Uses coalesce to handle null full_name values during insertion and update.
- Update public.users trigger to also update `updated_at` when user data changes.
- Implement cascading updates and deletes on user_id foreign keys across multiple tables.
- Cascade changes applied to leave_requests, project_assignments, addresses, extended_absences and bonus_leave_grants tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate user profiles on signup by upserting by email.
  * Preserve existing full name when new signups lack a name.
  * Keep user ID synchronized with authentication while avoiding overwriting profile email.
  * Create new profiles with default role “employee” and blank optional fields.
  * Ensure related records update or are removed automatically when a user’s ID changes or the user is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
